### PR TITLE
fix: Remove remaining pandas usage from Anytone 878 formatters

### DIFF
--- a/src/radiobridge/radios/anytone_878_v3.py
+++ b/src/radiobridge/radios/anytone_878_v3.py
@@ -2,9 +2,8 @@
 
 from typing import List, Optional
 
-import pandas as pd
-
 from .base import BaseRadioFormatter
+from ..lightweight_data import LightDataFrame
 from .metadata import RadioMetadata
 from .enhanced_metadata import (
     EnhancedRadioMetadata,
@@ -172,19 +171,19 @@ class Anytone878V3Formatter(BaseRadioFormatter):
 
     def format(
         self,
-        data: pd.DataFrame,
+        data: LightDataFrame,
         start_channel: int = 1,
         cps_version: Optional[str] = None,
-    ) -> pd.DataFrame:
+    ) -> LightDataFrame:
         """Format repeater data for Anytone 878 firmware/CPS 3.0x.
 
         Args:
-            data: Input DataFrame with repeater information
+            data: Input LightDataFrame with repeater information
             start_channel: Starting channel number (default: 1)
             cps_version: CPS version to optimize output for (optional)
 
         Returns:
-            Formatted DataFrame ready for Anytone firmware/CPS 3.0x import
+            Formatted LightDataFrame ready for Anytone firmware/CPS 3.0x import
         """
         self.validate_input(data)
 
@@ -201,7 +200,8 @@ class Anytone878V3Formatter(BaseRadioFormatter):
         formatted_data = []
         channel_names = []  # Collect names for conflict resolution
 
-        for idx, row in data.iterrows():
+        for idx in range(len(data)):
+            row = data.iloc(idx)
             channel = idx + start_channel
 
             # Get RX frequency (works with both basic and detailed downloader)
@@ -289,7 +289,7 @@ class Anytone878V3Formatter(BaseRadioFormatter):
         for i, resolved_name in enumerate(resolved_names):
             formatted_data[i]["Channel Name"] = resolved_name
 
-        result_df = pd.DataFrame(formatted_data)
+        result_df = LightDataFrame.from_records(formatted_data)
         self.logger.info(
             f"Format operation complete: {len(result_df)} channels formatted"
         )

--- a/src/radiobridge/radios/anytone_878_v4.py
+++ b/src/radiobridge/radios/anytone_878_v4.py
@@ -2,9 +2,8 @@
 
 from typing import List, Optional
 
-import pandas as pd
-
 from .base import BaseRadioFormatter
+from ..lightweight_data import LightDataFrame
 from .metadata import RadioMetadata
 from .enhanced_metadata import (
     EnhancedRadioMetadata,
@@ -154,19 +153,19 @@ class Anytone878V4Formatter(BaseRadioFormatter):
 
     def format(
         self,
-        data: pd.DataFrame,
+        data: LightDataFrame,
         start_channel: int = 1,
         cps_version: Optional[str] = None,
-    ) -> pd.DataFrame:
+    ) -> LightDataFrame:
         """Format repeater data for Anytone 878 firmware/CPS 4.0.
 
         Args:
-            data: Input DataFrame with repeater information
+            data: Input LightDataFrame with repeater information
             start_channel: Starting channel number (default: 1)
             cps_version: CPS version to optimize output for (optional)
 
         Returns:
-            Formatted DataFrame ready for Anytone firmware/CPS 4.0 import
+            Formatted LightDataFrame ready for Anytone firmware/CPS 4.0 import
         """
         self.validate_input(data)
 
@@ -183,7 +182,8 @@ class Anytone878V4Formatter(BaseRadioFormatter):
         formatted_data = []
         channel_names = []  # Collect names for conflict resolution
 
-        for idx, row in data.iterrows():
+        for idx in range(len(data)):
+            row = data.iloc(idx)
             channel = idx + start_channel
 
             # Get RX frequency (works with both basic and detailed downloader)
@@ -273,7 +273,7 @@ class Anytone878V4Formatter(BaseRadioFormatter):
         for i, resolved_name in enumerate(resolved_names):
             formatted_data[i]["Channel Name"] = resolved_name
 
-        result_df = pd.DataFrame(formatted_data)
+        result_df = LightDataFrame.from_records(formatted_data)
         self.logger.info(
             f"Format operation complete: {len(result_df)} channels formatted"
         )


### PR DESCRIPTION
This PR removes the remaining pandas imports from the Anytone 878 v3 and v4 formatters that were missed in the main pandas removal effort.

Changes made:
- Remove pandas imports from anytone_878_v3.py and anytone_878_v4.py
- Replace pandas.DataFrame with LightDataFrame in type hints and method signatures
- Update iterrows() usage to work with LightDataFrame iteration pattern
- Import LightDataFrame instead of pandas

This is a follow-up to PR #16 which completed the major pandas removal. After this PR, the RadioBridge project will be 100% pandas-free across all active source code.